### PR TITLE
fix CWE-1104 : JCenter/Bintray deprecated

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,11 +26,6 @@
 
     <repositories>
         <repository>
-            <id>jcenter</id>
-            <name>jcenter-bintray</name>
-            <url>https://jcenter.bintray.com</url>
-        </repository>
-        <repository>
             <id>dv8tion</id>
             <name>m2-dv8tion</name>
             <url>https://m2.dv8tion.net/releases</url>


### PR DESCRIPTION
[Bintray and JCenter are shutting down on February 1st, 2022](https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/). Relying upon repositories that are deprecated or scheduled to be shutdown can have unintended consequences; for example, artifacts being resolved from a different artifact server or a total failure of the CI build.

fix #7 

