### PR TITLE
Fix Sonar build

### DIFF
--- a/.github/workflows/sonar-gate.yml
+++ b/.github/workflows/sonar-gate.yml
@@ -18,13 +18,13 @@ jobs:
         with:
           java-version: 17
       - name: Cache SonarCloud packages
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: ~/.sonar/cache
           key: ${{ runner.os }}-sonar
           restore-keys: ${{ runner.os }}-sonar
       - name: Cache Maven packages
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}


### PR DESCRIPTION
This pull request updates the caching actions in the SonarCloud workflow to use the latest version. 

Workflow updates:

* [`.github/workflows/sonar-gate.yml`](diffhunk://#diff-b8d830cbedad0068a91bbf8c318beeb1368f22905d97eacce8d8d0ea5a1986b2L21-R27): Updated the `actions/cache` version from `v1` to `v4` for both SonarCloud packages and Maven packages caching steps.