### PR TITLE
Update dependencies

### DIFF
--- a/.github/workflows/sonar-gate.yml
+++ b/.github/workflows/sonar-gate.yml
@@ -1,4 +1,4 @@
-name: sonar-gate
+name: SonarQube
 on:
   push:
     branches:
@@ -7,17 +7,18 @@ on:
     types: [opened, synchronize, reopened]
 jobs:
   build:
-    name: Build
+    name: Build and analyze
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
       - name: Set up JDK 17
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
           java-version: 17
-      - name: Cache SonarCloud packages
+          distribution: 'temurin'
+      - name: Cache SonarQube packages
         uses: actions/cache@v4
         with:
           path: ~/.sonar/cache
@@ -31,6 +32,5 @@ jobs:
           restore-keys: ${{ runner.os }}-m2
       - name: Build and analyze
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: mvn -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar

--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,7 @@
         <dependency>
             <groupId>org.liquibase</groupId>
             <artifactId>liquibase-core</artifactId>
-            <version>4.29.2</version>
+            <version>4.31.0</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/xyz.brandonfl/throwable-optional -->

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-configuration-processor</artifactId>
-            <version>3.3.5</version>
+            <version>3.4.2</version>
             <optional>true</optional>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
         <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-core</artifactId>
-            <version>6.6.1.Final</version>
+            <version>6.6.5.Final</version>
             <type>pom</type>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -153,7 +153,7 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
-                <version>3.3.5</version>
+                <version>3.4.2</version>
                 <executions>
                     <execution>
                         <goals>

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-tomcat</artifactId>
-            <version>3.3.5</version>
+            <version>3.4.2</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
         <dependency>
             <groupId>net.dv8tion</groupId>
             <artifactId>JDA</artifactId>
-            <version>5.1.2</version>
+            <version>5.2.3</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -121,7 +121,7 @@
         <dependency>
             <groupId>io.sentry</groupId>
             <artifactId>sentry-spring-boot-starter-jakarta</artifactId>
-            <version>7.14.0</version>
+            <version>8.1.0</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-jpa</artifactId>
-            <version>3.3.5</version>
+            <version>3.4.2</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-configuration-processor -->

--- a/pom.xml
+++ b/pom.xml
@@ -173,7 +173,7 @@
             <plugin>
                 <groupId>org.liquibase</groupId>
                 <artifactId>liquibase-maven-plugin</artifactId>
-                <version>4.29.2</version>
+                <version>4.31.0</version>
                 <configuration>
                     <propertyFile>src/main/resources/application.properties</propertyFile>
                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.3.5</version>
+        <version>3.4.2</version>
     </parent>
 
     <properties>

--- a/src/main/java/com/brandonfl/discordrolepersistence/config/AsyncExecutorConfiguration.java
+++ b/src/main/java/com/brandonfl/discordrolepersistence/config/AsyncExecutorConfiguration.java
@@ -25,7 +25,6 @@
 package com.brandonfl.discordrolepersistence.config;
 
 import java.util.concurrent.Executor;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
@@ -34,7 +33,6 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 public class AsyncExecutorConfiguration {
 
   @Bean(name = "userPersistenceExecutor")
-  @Autowired
   public Executor userPersistenceExecutor(BotProperties botProperties) {
     ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
     executor.setCorePoolSize(botProperties.getSetting().getPersistence().getUser().getThreadNumber());
@@ -44,7 +42,6 @@ public class AsyncExecutorConfiguration {
   }
 
   @Bean(name = "rolePersistenceExecutor")
-  @Autowired
   public Executor rolePersistenceExecutor(BotProperties botProperties) {
     ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
     executor.setCorePoolSize(botProperties.getSetting().getPersistence().getRole().getThreadNumber());
@@ -54,7 +51,6 @@ public class AsyncExecutorConfiguration {
   }
 
   @Bean(name = "serverPersistenceExecutor")
-  @Autowired
   public Executor serverPersistenceExecutor(BotProperties botProperties) {
     ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
     executor.setCorePoolSize(botProperties.getSetting().getPersistence().getServer().getThreadNumber());

--- a/src/main/java/com/brandonfl/discordrolepersistence/config/datasource/DataSourceConfig.java
+++ b/src/main/java/com/brandonfl/discordrolepersistence/config/datasource/DataSourceConfig.java
@@ -27,7 +27,6 @@ package com.brandonfl.discordrolepersistence.config.datasource;
 import java.text.MessageFormat;
 import java.util.Objects;
 import javax.sql.DataSource;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.jdbc.DataSourceBuilder;
@@ -39,7 +38,6 @@ public class DataSourceConfig {
 
   @ConditionalOnExpression("!T(org.springframework.util.StringUtils).isEmpty('${bot-datasource.host:}')")
   @Bean("mysqlDataSource")
-  @Autowired
   public DataSource mysqlDataSource(DataSourceProperties dataSourceProperties) {
     DataSourceBuilder<?> dataSourceBuilder = DataSourceBuilder.create();
     dataSourceBuilder.driverClassName("com.mysql.cj.jdbc.Driver");
@@ -55,7 +53,6 @@ public class DataSourceConfig {
 
   @ConditionalOnMissingBean(name = "mysqlDataSource")
   @Bean("h2DataSource")
-  @Autowired
   public DataSource h2DataSource(DataSourceProperties dataSourceProperties) {
     DataSourceBuilder<?> dataSourceBuilder = DataSourceBuilder.create();
     dataSourceBuilder.driverClassName("org.h2.Driver");


### PR DESCRIPTION
This pull request includes dependency and plugin version upgrades in `pom.xml` as well as code cleanup in configuration classes by removing unnecessary `@Autowired` annotations. These changes aim to improve dependency management and simplify the codebase.

### Dependency and Plugin Updates:
* Updated the Spring Boot parent version from `3.3.5` to `3.4.2` and synchronized related dependencies (`spring-boot-starter-tomcat`, `spring-boot-starter-data-jpa`, `spring-boot-configuration-processor`, and `spring-boot-maven-plugin`) to the same version. (`pom.xml`: [[1]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L15-R15) [[2]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L40-R40) [[3]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L52-R66) [[4]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L156-R156)
* Upgraded third-party dependencies:
  - `JDA` from `5.1.2` to `5.2.3` (`pom.xml`: [pom.xmlL52-R66](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L52-R66))
  - `hibernate-core` from `6.6.1.Final` to `6.6.5.Final` (`pom.xml`: [pom.xmlL89-R89](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L89-R89))
  - `liquibase-core` and `liquibase-maven-plugin` from `4.29.2` to `4.31.0` (`pom.xml`: [[1]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L111-R111) [[2]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L176-R176)
  - `sentry-spring-boot-starter-jakarta` from `7.14.0` to `8.1.0` (`pom.xml`: [pom.xmlL124-R124](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L124-R124))

### Code Cleanup:
* Removed unnecessary `@Autowired` annotations from bean definitions in configuration classes:
  - `AsyncExecutorConfiguration.java` (`userPersistenceExecutor`, `rolePersistenceExecutor`, `serverPersistenceExecutor`) [[1]](diffhunk://#diff-bdc8820459cd49463053df7a1619024eb6d1cb0b745b98464537e9f00801a038L28) [[2]](diffhunk://#diff-bdc8820459cd49463053df7a1619024eb6d1cb0b745b98464537e9f00801a038L37) [[3]](diffhunk://#diff-bdc8820459cd49463053df7a1619024eb6d1cb0b745b98464537e9f00801a038L47) [[4]](diffhunk://#diff-bdc8820459cd49463053df7a1619024eb6d1cb0b745b98464537e9f00801a038L57)
  - `DataSourceConfig.java` (`mysqlDataSource`, `h2DataSource`) [[1]](diffhunk://#diff-db11add1e373a52ff197c1cee6e010c22e9f53e0fc4ca1426b439b096a4dc688L30) [[2]](diffhunk://#diff-db11add1e373a52ff197c1cee6e010c22e9f53e0fc4ca1426b439b096a4dc688L42) [[3]](diffhunk://#diff-db11add1e373a52ff197c1cee6e010c22e9f53e0fc4ca1426b439b096a4dc688L58)